### PR TITLE
suppport unauthenticated access

### DIFF
--- a/request.go
+++ b/request.go
@@ -15,7 +15,11 @@ import (
 // Request implements the basic Request function
 func (a *API) Request(req *http.Request) ([]byte, error) {
 	req.Header.Add("Accept", "application/json, */*")
-	a.Auth(req)
+	//Supports unauthenticated access to confluence:
+	//if username and token are not set, do not add authorization header
+	if a.username != "" && a.token != "" {
+		a.Auth(req)
+	}
 
 	Debug("====== Request ======")
 	Debug(req)


### PR DESCRIPTION
This simple fix will let a user specify no username or password in the api to access the confluence without auth (for anonymous confluence access)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [ ] documentation is added or changed
