### PR TITLE
Handle empty response body

### DIFF
--- a/request.go
+++ b/request.go
@@ -97,12 +97,12 @@ func (a *API) SendContentRequest(ep *url.URL, method string, c *Content) (*Conte
 	}
 
 	var content Content
-
-	err = json.Unmarshal(res, &content)
-	if err != nil {
-		return nil, err
+	if len(res) != 0 {
+		err = json.Unmarshal(res, &content)
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	return &content, nil
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -299,7 +299,12 @@ func confluenceRestAPIStub() *httptest.Server {
 		case "/wiki/rest/api/content/":
 			resp = Content{}
 		case "/wiki/rest/api/content/42":
-			resp = Content{}
+			if r.Method == "DELETE" {
+				resp = ""
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				resp = Content{}
+			}
 		case "/wiki/rest/api/user?username=42":
 			resp = User{}
 		case "/wiki/rest/api/user?accountId=42":


### PR DESCRIPTION
- [ X] `mage test` passes
- [ X] unit tests are included and tested

This just adds a simple `len` check on the response body in `SendContentRequest`. This is to mitigate #35 . 

This didn't break any other test, and I can't think of a downside of skipping JSON unmarshalling if the len of body's bytes is 0. :shrug: 