### PR TITLE
Add settings to set editor type and width of pages created

### DIFF
--- a/content.go
+++ b/content.go
@@ -35,25 +35,30 @@ type Content struct {
 	Metadata  *Metadata  `json:"metadata"`
 }
 
+// Metadata specifies metadata properties
 type Metadata struct {
 	Properties *Properties `json:"properties"`
 }
 
+// Properties defines properties of the editor
 type Properties struct {
 	Editor                     *Editor                     `json:"editor"`
 	ContentAppearanceDraft     *ContentAppearanceDraft     `json:"content-appearance-draft"`
 	ContentAppearancePublished *ContentAppearancePublished `json:"content-appearance-published"`
 }
 
+// Editor contains editor information
 type Editor struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
+// ContentAppearanceDraft sets the appearance of the content in draft form
 type ContentAppearanceDraft struct {
 	Value string `json:"value"`
 }
 
+// ContentAppearancePublished sets the appearance of the content in published form
 type ContentAppearancePublished struct {
 	Value string `json:"value"`
 }

--- a/content.go
+++ b/content.go
@@ -32,6 +32,20 @@ type Content struct {
 	Space     Space      `json:"space"`
 	History   *History   `json:"history,omitempty"`
 	Links     *Links     `json:"_links,omitempty"`
+	Metadata  *Metadata  `json:"metadata"`
+}
+
+type Metadata struct {
+	Properties *Properties
+}
+
+type Properties struct {
+	Editor *Editor
+}
+
+type Editor struct {
+	Key   string
+	Value string
 }
 
 // Links contains link information

--- a/content.go
+++ b/content.go
@@ -40,12 +40,22 @@ type Metadata struct {
 }
 
 type Properties struct {
-	Editor *Editor `json:"editor"`
+	Editor                     *Editor                     `json:"editor"`
+	ContentAppearanceDraft     *ContentAppearanceDraft     `json:"content-appearance-draft"`
+	ContentAppearancePublished *ContentAppearancePublished `json:"content-appearance-published"`
 }
 
 type Editor struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+type ContentAppearanceDraft struct {
+	Value string `json:"content-appearance-draft"`
+}
+
+type ContentAppearancePublished struct {
+	Value string `json:"content-appearance-published"`
 }
 
 // Links contains link information

--- a/content.go
+++ b/content.go
@@ -51,11 +51,11 @@ type Editor struct {
 }
 
 type ContentAppearanceDraft struct {
-	Value string `json:"content-appearance-draft"`
+	Value string `json:"value"`
 }
 
 type ContentAppearancePublished struct {
-	Value string `json:"content-appearance-published"`
+	Value string `json:"value"`
 }
 
 // Links contains link information

--- a/content.go
+++ b/content.go
@@ -36,16 +36,16 @@ type Content struct {
 }
 
 type Metadata struct {
-	Properties *Properties
+	Properties *Properties `json:"properties"`
 }
 
 type Properties struct {
-	Editor *Editor
+	Editor *Editor `json:"editor"`
 }
 
 type Editor struct {
-	Key   string
-	Value string
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // Links contains link information

--- a/examples/content/content.go
+++ b/examples/content/content.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/virtomize/confluence-go-api"
+	goconfluence "github.com/virtomize/confluence-go-api"
 )
 
 func main() {
@@ -50,7 +50,7 @@ func main() {
 				Representation: "storage",
 			},
 		},
-		Version: goconfluence.Version{
+		Version: &goconfluence.Version{
 			Number: 1,
 		},
 		Space: goconfluence.Space{
@@ -81,7 +81,7 @@ func main() {
 				Representation: "storage",
 			},
 		},
-		Version: goconfluence.Version{
+		Version: &goconfluence.Version{
 			Number: 2,
 		},
 		Space: goconfluence.Space{


### PR DESCRIPTION
This MR brings in some properties you can set when creating or updating a Confluence page. 
The `Editor` property can be specified between "v1" & "v2". This will explicitly set whether to use the new or old Confluence editor to create/update pages. 
The `ContentAppearanceDraft` & `ContentAppearancePublished` will set the width of the page created or updated. Found this setting through this thread [here](https://community.developer.atlassian.com/t/make-layout-full-width-when-creating-page/40461/3).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed
