### PR TITLE
Add Download field into struct Links

### DIFF
--- a/content.go
+++ b/content.go
@@ -65,9 +65,10 @@ type ContentAppearancePublished struct {
 
 // Links contains link information
 type Links struct {
-	Base   string `json:"base"`
-	TinyUI string `json:"tinyui"`
-	WebUI  string `json:"webui"`
+	Base     string `json:"base"`
+	TinyUI   string `json:"tinyui"`
+	WebUI    string `json:"webui"`
+	Download string `json:"download"`
 }
 
 // Ancestor defines ancestors to create sub pages


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `mage test` passes
- [ ] unit tests are included and tested
- [ ] documentation is added or changed

I hope I'm not making a fool out of myself by missing something completely obvious, but nowhere in godoc or examples could I find a way how to download (binary) attachment contents. Confluence's REST API provides a `download` link for attachments, but the `Links` struct contained no such field.

This PR merely adds that one field.
