### PR TITLE
Add ownedBy to History struct

### DIFF
--- a/content.go
+++ b/content.go
@@ -259,6 +259,7 @@ type History struct {
 	Latest      bool        `json:"latest"`
 	CreatedBy   User        `json:"createdBy"`
 	CreatedDate string      `json:"createdDate"`
+	OwnedBy     User        `json:"ownedBy"`
 }
 
 // LastUpdated  contains information about the last update


### PR DESCRIPTION
This PR adds the `ownedBy` optional field to the Content History response structure.

Example use:

```
GetContentByID(page.ID, goconfluence.ContentQuery{
   Expand: []string{"history.ownedBy"},
})
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `mage test` passes
- [ ] unit tests are included and tested
- [ ] documentation is added or changed
