### PR TITLE
Add SearchWithNext method to allow paging

### DIFF
--- a/examples/search/search.go
+++ b/examples/search/search.go
@@ -29,4 +29,20 @@ func main() {
 		fmt.Printf("%+v\n", v)
 	}
 
+	// search example with paging using SearchWithNext and Links.Next
+	next := ""
+	for {
+		resp, err := api.SearchWithNext(query, next)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, v := range result.Results {
+			fmt.Printf("%+v\n", v)
+		}
+		next = resp.Links.Next
+		if next == "" {
+			break
+		}
+		log.Printf("Using next page: %s", next)
+	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -343,6 +343,8 @@ func confluenceRestAPIStub() *httptest.Server {
 			resp = User{}
 		case "/wiki/rest/api/search":
 			resp = Search{}
+		case "/wiki/rest/api/search?next=true&cursor=abc123":
+			resp = Search{}
 		case "/wiki/rest/api/content/42/history":
 			resp = History{}
 		case "/wiki/rest/api/content/42/label":

--- a/search_test.go
+++ b/search_test.go
@@ -11,8 +11,8 @@ func TestSearchQueryParams(t *testing.T) {
 		CQL:                   "test",
 		CQLContext:            "test",
 		IncludeArchivedSpaces: true,
-		Limit: 1,
-		Start: 1,
+		Limit:                 1,
+		Start:                 1,
 	}
 	p := addSearchQueryParams(query)
 	assert.Equal(t, p.Get("cql"), "test")
@@ -33,4 +33,20 @@ func TestSearch(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &Search{}, s)
 
+}
+
+func TestSearchWithNext(t *testing.T) {
+	server := confluenceRestAPIStub()
+	defer server.Close()
+
+	api, err := NewAPI(server.URL+"/wiki/rest/api", "userame", "token")
+	assert.Nil(t, err)
+
+	s, err := api.SearchWithNext(SearchQuery{}, "")
+	assert.Nil(t, err)
+	assert.Equal(t, &Search{}, s)
+
+	s, err = api.SearchWithNext(SearchQuery{}, "/rest/api/search?next=true&cursor=abc123")
+	assert.Nil(t, err)
+	assert.Equal(t, &Search{}, s)
 }


### PR DESCRIPTION
Parsing the `_links` section of search results in order to allow paging. Added example in `examples/search/search.go` with how this can be used. Note: it appears the `Start` param is not respected at all by Confluence API.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed
