### PR TITLE
Add ContentQuery param to GetComments and GetAttachments

### DIFF
--- a/content.go
+++ b/content.go
@@ -236,20 +236,22 @@ func (a *API) GetChildPages(id string) (*Search, error) {
 }
 
 // GetComments returns a list of comments belonging to id
-func (a *API) GetComments(id string) (*Search, error) {
+func (a *API) GetComments(id string, query ContentQuery) (*Search, error) {
 	ep, err := a.getContentChildEndpoint(id, "comment")
 	if err != nil {
 		return nil, err
 	}
+	ep.RawQuery = addContentQueryParams(query).Encode()
 	return a.SendSearchRequest(ep, "GET")
 }
 
 // GetAttachments returns a list of attachments belonging to id
-func (a *API) GetAttachments(id string) (*Search, error) {
+func (a *API) GetAttachments(id string, query ContentQuery) (*Search, error) {
 	ep, err := a.getContentChildEndpoint(id, "attachment")
 	if err != nil {
 		return nil, err
 	}
+	ep.RawQuery = addContentQueryParams(query).Encode()
 	return a.SendSearchRequest(ep, "GET")
 }
 

--- a/content_test.go
+++ b/content_test.go
@@ -47,11 +47,11 @@ func TestContentGetter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &Search{}, p)
 
-	p, err = api.GetComments("42")
+	p, err = api.GetComments("42", ContentQuery{})
 	assert.Nil(t, err)
 	assert.Equal(t, &Search{}, p)
 
-	p, err = api.GetAttachments("42")
+	p, err = api.GetAttachments("42", ContentQuery{})
 	assert.Nil(t, err)
 	assert.Equal(t, &Search{}, p)
 

--- a/examples/attributes/attributes.go
+++ b/examples/attributes/attributes.go
@@ -14,7 +14,7 @@ func main() {
 	}
 
 	// get comments of a specific page
-	res, err := api.GetComments("1234567")
+	res, err := api.GetComments("1234567", goconfluence.ContentQuery{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	// get attachments of a specific page
-	res, err = api.GetAttachments("1234567")
+	res, err = api.GetAttachments("1234567", goconfluence.ContentQuery{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/virtomize/confluence-go-api/blob/master/CONTRIBUTING.md
-->

This PR includes the changes to support passing query parameters for the `GetComments()` and `GetAttachments()` methods. This is something I needed in my project and thought should be included in the package as well.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed
